### PR TITLE
Make the package command more useful

### DIFF
--- a/conf/commands.yml
+++ b/conf/commands.yml
@@ -37,6 +37,9 @@ purge:
 # touching the current installation.
 package:
   - make
+  - copy
+  - link
+  #example: - shell: rm -rf _build/sites/all/themes/custom/<themename>/node_modules
   - shell: cp conf/_ping.php _build
   - shell: tar cvfz package.tgz _build
   - shell: rm -rf _build

--- a/conf/commands.yml
+++ b/conf/commands.yml
@@ -37,7 +37,6 @@ purge:
 # touching the current installation.
 package:
   - make
-  - copy
   - link
   #example: - shell: rm -rf _build/sites/all/themes/custom/<themename>/node_modules
   - shell: cp conf/_ping.php _build


### PR DESCRIPTION
A package that doesn't have the custom features, themes & modules is not very useful
Also added a commented out example on how to (ok in a bit dumb way) clean out a themer's node_modules - you don't really want to send that to production
