### PR TITLE
Updated commands.yml to be in sync with site.yml definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
 .make_cache
 builds
-drupal
+current
 drupal.sqlite

--- a/conf/commands.yml
+++ b/conf/commands.yml
@@ -8,26 +8,26 @@ new:
   - verify: "Type yes to verify you want to build a new installation: "
   - make
   - backup
-  - shell: chmod -R a+w drupal
+  - shell: chmod -R a+w current
   - purge
   - finalize
   - install
   - cleanup
-  - shell: chmod -R a-w drupal
+  - shell: chmod -R a-w current
 
 
 # Basic site update functionality
 update:
   - make
   - backup
-  - shell: chmod -R a+w drupal
+  - shell: chmod -R a+w current
   - finalize
   - update
   - cleanup
-  - shell: chmod -R a-w drupal
+  - shell: chmod -R a-w current
 
 reinstall:
-  - shell: cd drupal && drush sql-drop -y
+  - shell: cd current && drush sql-drop -y
 
 purge:
   - purge
@@ -51,8 +51,8 @@ backup:
 
 hotfix:
   - link
-  - shell: chmod -R ug+w drupal
-  - shell: rsync -a _build/ drupal
+  - shell: chmod -R ug+w current
+  - shell: rsync -a _build/ current
   - shell: rm -r _build
-  - shell: chmod -R a-w drupal
+  - shell: chmod -R a-w current
   - update

--- a/conf/commands.yml
+++ b/conf/commands.yml
@@ -8,23 +8,23 @@ new:
   - verify: "Type yes to verify you want to build a new installation: "
   - make
   - backup
-  - shell: chmod -R a+w current
+  - shell: chmod -R a+w drupal
   - purge
   - finalize
   - install
   - cleanup
-  - shell: chmod -R a-w current
+  - shell: chmod -R a-w drupal
 
 
 # Basic site update functionality
 update:
   - make
   - backup
-  - shell: chmod -R a+w current
+  - shell: chmod -R a+w drupal
   - finalize
   - update
   - cleanup
-  - shell: chmod -R a-w current
+  - shell: chmod -R a-w drupal
 
 reinstall:
   - shell: cd drupal && drush sql-drop -y
@@ -51,8 +51,8 @@ backup:
 
 hotfix:
   - link
-  - shell: chmod -R ug+w current
-  - shell: rsync -a _build/ current
+  - shell: chmod -R ug+w drupal
+  - shell: rsync -a _build/ drupal
   - shell: rm -r _build
-  - shell: chmod -R a-w current
+  - shell: chmod -R a-w drupal
   - update

--- a/conf/site.yml
+++ b/conf/site.yml
@@ -21,7 +21,7 @@ default:
   make_cache: .make_cache
 
   # The final produced Drupal installation
-  final: drupal
+  final: current
 
   # Directory which will house all the previous builds
   previous: builds


### PR DESCRIPTION
In site.yml final drupal installation is referenced to 'drupal' directory whereas in commands.yml all permission settings are referenced to 'current' directory.

As a result of this "chmod: cannot access current: No such file or directory" error is displayed if build is done using default settings. 
