### PR TITLE
Add support for having Drupal bootstrapped from other than sites/defa…

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -91,6 +91,7 @@ class Maker:
 		self.composer = settings.get('composer', 'composer')
 		self.drush = settings.get('drush', 'drush')
 		self.type = settings.get('type', 'drush make')
+                self.drupal_version = settings.get('drupal_version', 'd7')
 		self.drupal_subpath = settings.get('drupal_subpath', '')
 		self.temp_build_dir_name = settings['temporary']
 		self.temp_build_dir = os.path.abspath(self.temp_build_dir_name)
@@ -494,11 +495,18 @@ class Maker:
 		tar.close()
 
         def passwd(self):
-            query = "SELECT name from users WHERE uid=1"
-            uid1_name = self._drush(['--root=' + format(self.final_build_dir + self.drupal_subpath),
-            'sqlq',
-            query
-            ], False, True)
+            if self.version == 'd7':
+                query = "SELECT name from users WHERE uid=1"
+                uid1_name = self._drush(['--root=' + format(self.final_build_dir + self.drupal_subpath),
+                'sqlq',
+                query
+                ], False, True)
+            else:
+                query = "print user_load(1)->getUsername();"
+                uid1_name = self._drush(['--root=' + format(self.final_build_dir + self.drupal_subpath),
+                'ev',
+                query
+                ], False, True)
 
             char_set = string.printable
             password = ''.join(random.sample(char_set*6, 16))

--- a/build.sh
+++ b/build.sh
@@ -497,14 +497,14 @@ class Maker:
                 query = "SELECT name from users WHERE uid=1"
                 uid1_name = self._drush(
                 'sqlq',
-                query
-                ], False, True)
+                query,
+                False, True)
             else:
                 query = "print user_load(1)->getUsername();"
                 uid1_name = self._drush(
                 'ev',
-                query
-                ], False, True)
+                query,
+                False, True)
             query = "SELECT name from users WHERE uid=1"
             uid1_name = self._drush(
             'sqlq',

--- a/build.sh
+++ b/build.sh
@@ -441,7 +441,6 @@ class Maker:
 			return subprocess.call([self.drush] + bootstrap_args + args, stdout=FNULL, stderr=FNULL) == 0
                 if output:
                         return subprocess.check_output([self.drush] + bootstrap_args + args)
-		print bootstrap_args + args										
 		return subprocess.call([self.drush] + bootstrap_args + args) == 0
 
 	# Ensure directories exist

--- a/build.sh
+++ b/build.sh
@@ -495,21 +495,21 @@ class Maker:
         def passwd(self):
             if self.drupal_version == 'd7':
                 query = "SELECT name from users WHERE uid=1"
-                uid1_name = self._drush(
+                uid1_name = self._drush([
                 'sqlq',
-                query,
-                False, True)
+                query
+                ], False, True)
             else:
                 query = "print user_load(1)->getUsername();"
-                uid1_name = self._drush(
+                uid1_name = self._drush([
                 'ev',
-                query,
-                False, True)
+                query
+                ], False, True)
             query = "SELECT name from users WHERE uid=1"
-            uid1_name = self._drush(
+            uid1_name = self._drush([
             'sqlq',
             query
-            , False, True)
+            ], False, True)
             char_set = string.printable
             password = ''.join(random.sample(char_set*6, 16))
 

--- a/build.sh
+++ b/build.sh
@@ -102,6 +102,7 @@ class Maker:
 		self.old_build_dir = os.path.abspath(settings.get('previous', 'previous'))
 		self.profile_name = settings.get('profile', 'standard')
 		self.site_name = settings.get('site', 'A drupal site')
+		self.multisite_site = settings.get('multisite_site', 'default')
 		self.make_cache_dir = settings.get('make_cache', '.make_cache')
 		self.settings = settings
 		self.store_old_buids = True
@@ -283,6 +284,8 @@ class Maker:
 	def install(self):
 		if not self._drush([
 			"--root=" + format(self.final_build_dir + self.drupal_subpath),
+			"-l",
+			self.multisite_site,
 			"site-install",
 			self.profile_name,
 			"install_configure_form.update_status_module='array(FALSE,FALSE)'"
@@ -297,6 +300,8 @@ class Maker:
 	def update(self):
 		if self._drush([
 			"--root=" + format(self.final_build_dir + self.drupal_subpath),
+			"-l",
+			self.multisite_site,
 			'updatedb',
 			'--y'
 		]):

--- a/build.sh
+++ b/build.sh
@@ -440,7 +440,6 @@ class Maker:
 			return subprocess.call([self.drush] + bootstrap_args + args, stdout=FNULL, stderr=FNULL) == 0
                 if output:
                         return subprocess.check_output([self.drush] + bootstrap_args + args)
-		print bootstrap_args + args										
 		return subprocess.call([self.drush] + bootstrap_args + args) == 0
 
 	# Ensure directories exist

--- a/build.sh
+++ b/build.sh
@@ -283,9 +283,6 @@ class Maker:
 	# Run install
 	def install(self):
 		if not self._drush([
-			"--root=" + format(self.final_build_dir + self.drupal_subpath),
-			"-l",
-			self.multisite_site,
 			"site-install",
 			self.profile_name,
 			"install_configure_form.update_status_module='array(FALSE,FALSE)'"
@@ -299,9 +296,6 @@ class Maker:
 	# Update existing final build
 	def update(self):
 		if self._drush([
-			"--root=" + format(self.final_build_dir + self.drupal_subpath),
-			"-l",
-			self.multisite_site,
 			'updatedb',
 			'--y'
 		]):
@@ -331,9 +325,8 @@ class Maker:
 
 	# Execute a drush command
 	def drush_command(self, command):
-            drush_command = ['--root=' + format(self.final_build_dir + self.drupal_subpath)] + command.split(' ')
+            drush_command = command.split(' ')
             return self._drush(drush_command, False)
-
 
 	def append(self, command):
 		files = command.split(">")
@@ -443,12 +436,14 @@ class Maker:
 
 	# Execute a drush command
 	def _drush(self, args, quiet = False, output = False):
+		bootstrap_args = ["--root=" + format(self.final_build_dir + self.drupal_subpath), "-l", self.multisite_site]
 		if quiet:
 			FNULL = open(os.devnull, 'w')
-			return subprocess.call([self.drush] + args, stdout=FNULL, stderr=FNULL) == 0
+			return subprocess.call([self.drush] + bootstrap_args + args, stdout=FNULL, stderr=FNULL) == 0
                 if output:
-                        return subprocess.check_output([self.drush] + args)
-		return subprocess.call([self.drush] + args) == 0
+                        return subprocess.check_output([self.drush] + bootstrap_args + args)
+		print bootstrap_args + args										
+		return subprocess.call([self.drush] + bootstrap_args + args) == 0
 
 	# Ensure directories exist
 	def _precheck(self):
@@ -476,7 +471,6 @@ class Maker:
 			gzdump_file = self.final_build_dir + '/db.sql.gz'
 
 			if self._drush([
-				"--root=" + format(self.final_build_dir + self.drupal_subpath),
 				'sql-dump',
 				'--result-file=' + dump_file
 			], True):
@@ -503,16 +497,15 @@ class Maker:
 
         def passwd(self):
             query = "SELECT name from users WHERE uid=1"
-            uid1_name = self._drush(['--root=' + format(self.final_build_dir + self.drupal_subpath),
+            uid1_name = self._drush(
             'sqlq',
             query
-            ], False, True)
+            , False, True)
 
             char_set = string.printable
             password = ''.join(random.sample(char_set*6, 16))
 
             if self._drush([
-                '--root=' + format(self.final_build_dir + self.drupal_subpath),
                 'upwd',
                 uid1_name,
                 '--password="' + password + '"'
@@ -524,7 +517,6 @@ class Maker:
         # Wipe existing final build
         def _wipe(self):
             if self._drush([
-                    '--root=' + format(self.final_build_dir + self.drupal_subpath),
                     'sql-drop',
                     '--y'
             ], True):

--- a/build.sh
+++ b/build.sh
@@ -101,6 +101,7 @@ class Maker:
 		self.old_build_dir = os.path.abspath(settings.get('previous', 'previous'))
 		self.profile_name = settings.get('profile', 'standard')
 		self.site_name = settings.get('site', 'A drupal site')
+		self.multisite_site = settings.get('multisite_site', 'default')
 		self.make_cache_dir = settings.get('make_cache', '.make_cache')
 		self.settings = settings
 		self.store_old_buids = True
@@ -282,6 +283,8 @@ class Maker:
 	def install(self):
 		if not self._drush([
 			"--root=" + format(self.final_build_dir + self.drupal_subpath),
+			"-l",
+			self.multisite_site,
 			"site-install",
 			self.profile_name,
 			"install_configure_form.update_status_module='array(FALSE,FALSE)'"
@@ -296,6 +299,8 @@ class Maker:
 	def update(self):
 		if self._drush([
 			"--root=" + format(self.final_build_dir + self.drupal_subpath),
+			"-l",
+			self.multisite_site,
 			'updatedb',
 			'--y'
 		]):

--- a/build.sh
+++ b/build.sh
@@ -282,9 +282,6 @@ class Maker:
 	# Run install
 	def install(self):
 		if not self._drush([
-			"--root=" + format(self.final_build_dir + self.drupal_subpath),
-			"-l",
-			self.multisite_site,
 			"site-install",
 			self.profile_name,
 			"install_configure_form.update_status_module='array(FALSE,FALSE)'"
@@ -298,9 +295,6 @@ class Maker:
 	# Update existing final build
 	def update(self):
 		if self._drush([
-			"--root=" + format(self.final_build_dir + self.drupal_subpath),
-			"-l",
-			self.multisite_site,
 			'updatedb',
 			'--y'
 		]):
@@ -330,9 +324,8 @@ class Maker:
 
 	# Execute a drush command
 	def drush_command(self, command):
-            drush_command = ['--root=' + format(self.final_build_dir + self.drupal_subpath)] + command.split(' ')
+            drush_command = command.split(' ')
             return self._drush(drush_command, False)
-
 
 	def append(self, command):
 		files = command.split(">")
@@ -442,12 +435,14 @@ class Maker:
 
 	# Execute a drush command
 	def _drush(self, args, quiet = False, output = False):
+		bootstrap_args = ["--root=" + format(self.final_build_dir + self.drupal_subpath), "-l", self.multisite_site]
 		if quiet:
 			FNULL = open(os.devnull, 'w')
-			return subprocess.call([self.drush] + args, stdout=FNULL, stderr=FNULL) == 0
+			return subprocess.call([self.drush] + bootstrap_args + args, stdout=FNULL, stderr=FNULL) == 0
                 if output:
-                        return subprocess.check_output([self.drush] + args)
-		return subprocess.call([self.drush] + args) == 0
+                        return subprocess.check_output([self.drush] + bootstrap_args + args)
+		print bootstrap_args + args										
+		return subprocess.call([self.drush] + bootstrap_args + args) == 0
 
 	# Ensure directories exist
 	def _precheck(self):
@@ -474,7 +469,6 @@ class Maker:
 			dump_file = self.final_build_dir + '/db.sql'
 
 			if self._drush([
-				"--root=" + format(self.final_build_dir + self.drupal_subpath),
 				'sql-dump',
 				'--result-file=' + dump_file
 			], True):
@@ -502,22 +496,25 @@ class Maker:
         def passwd(self):
             if self.drupal_version == 'd7':
                 query = "SELECT name from users WHERE uid=1"
-                uid1_name = self._drush(['--root=' + format(self.final_build_dir + self.drupal_subpath),
+                uid1_name = self._drush(
                 'sqlq',
                 query
                 ], False, True)
             else:
                 query = "print user_load(1)->getUsername();"
-                uid1_name = self._drush(['--root=' + format(self.final_build_dir + self.drupal_subpath),
+                uid1_name = self._drush(
                 'ev',
                 query
                 ], False, True)
-
+            query = "SELECT name from users WHERE uid=1"
+            uid1_name = self._drush(
+            'sqlq',
+            query
+            , False, True)
             char_set = string.printable
             password = ''.join(random.sample(char_set*6, 16))
 
             if self._drush([
-                '--root=' + format(self.final_build_dir + self.drupal_subpath),
                 'upwd',
                 uid1_name,
                 '--password="' + password + '"'
@@ -529,7 +526,6 @@ class Maker:
         # Wipe existing final build
         def _wipe(self):
             if self._drush([
-                    '--root=' + format(self.final_build_dir + self.drupal_subpath),
                     'sql-drop',
                     '--y'
             ], True):

--- a/build.sh
+++ b/build.sh
@@ -495,7 +495,7 @@ class Maker:
 		tar.close()
 
         def passwd(self):
-            if self.version == 'd7':
+            if self.drupal_version == 'd7':
                 query = "SELECT name from users WHERE uid=1"
                 uid1_name = self._drush(['--root=' + format(self.final_build_dir + self.drupal_subpath),
                 'sqlq',

--- a/conf/site.yml
+++ b/conf/site.yml
@@ -31,7 +31,11 @@ default:
 
   # Site name given at installation phase
   site: Wundersite
-
+  
+  # If the site is a multisite system where drupal is bootstrapped from a different directory than
+  # current/sites/default, you can define the folder here. Also note the symlink/copying of sites.php
+  #multisite_site: myspecialsite
+ 
   # In development environments we usually want to use symlinks, note the settings.php linking
   link:
     - files: sites/default/files
@@ -39,6 +43,8 @@ default:
     - code/themes: sites/all/themes/custom
     - code/profiles/wk: profiles/wk
     - conf/local.settings.php: sites/default/settings.php
+    # Only for multisite projects
+    #- conf/sites.php: sites/sites.php
     - conf/_ping.php: _ping.php
 
 # Test environment:

--- a/conf/site.yml
+++ b/conf/site.yml
@@ -34,7 +34,11 @@ default:
 
   # Site name given at installation phase
   site: Wundersite
-
+  
+  # If the site is a multisite system where drupal is bootstrapped from a different directory than
+  # current/sites/default, you can define the folder here. Also note the symlink/copying of sites.php
+  #multisite_site: myspecialsite
+ 
   # In development environments we usually want to use symlinks, note the settings.php linking
   link:
     - files: sites/default/files
@@ -42,6 +46,8 @@ default:
     - code/themes: sites/all/themes/custom
     - code/profiles/wk: profiles/wk
     - conf/local.settings.php: sites/default/settings.php
+    # Only for multisite projects
+    #- conf/sites.php: sites/sites.php
     - conf/_ping.php: _ping.php
 
 # Test environment:

--- a/conf/site.yml
+++ b/conf/site.yml
@@ -15,6 +15,9 @@ default:
   # The drush make file to use
   makefile: conf/site.make
 
+  # Define project Drupal version
+  drupal_version: d7
+
   # Directory used to build the site
   temporary: _build
 


### PR DESCRIPTION
…ult.

This adds support for multisite projects. build.sh adds a parameter to drush, -l,
that if set will make build.sh new and build.sh update work for legacy projects
that are based on sites.php/have the settings file in a different place than the
normal location - sites/default.
