### PR TITLE
Static analysis on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: python
+
+python:
+  - 2.7
+  - 3.5
+  - 3.4
+  - 3.3
+
+# Use container-based infrastructure
+sudo: false
+
+install:
+  - travis_retry pip install pyflakes
+
+script:
+  - pyflakes build.sh
+
+after_success:
+  - travis_retry pip install pep8
+  - pep8 --statistics --count build.sh
+
+matrix:
+  fast_finish: true
+
+  allow_failures:
+    - python: 3.5
+    - python: 3.4
+    - python: 3.3


### PR DESCRIPTION
We can use Travis CI to make sure the build.sh Python script is in good shape. This will run for every commit, and even better, for every PR so you can see if errors are introduced even before merging.

 * Pyflakes is a static analysis tool that looks for errors. If any are found, it will fail the build.

 * Pep8 is another static analysis tool to make sure it follows standard Python style conventions. Right now, this is only run for information only, and won't cause any builds to fail.

 * The tools are run on Python versions 2.7, 3.3, 3.4 and 3.5. Right now, 3.x builds are for information only, and won't cause any builds to fail.

Travis CI is a really useful CI tool which is free for open source projects such as this one. Please could someone with admin rights for wunderkraut/build.sh flip the switch at https://travis-ci.org/profile to allow Travis CI to run for wunderkraut/build.sh?

Thank you!