### PR TITLE
Lint YAML files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# Drupal editor configuration normalization
+# @see http://editorconfig.org/
+
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+# All files.
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[composer.json]
+indent_size = 4
+
+[*.py]
+# Four-space indentation
+indent_size = 4
+indent_style = space

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,11 @@ sudo: false
 
 install:
   - travis_retry pip install pyflakes
+  - travis_retry pip install yamllint
 
 script:
   - pyflakes build.sh
+  - yamllint .
 
 after_success:
   - travis_retry pip install pep8

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,8 @@
+# Extend default config by adjusting some options
+extends: default
+
+rules:
+  comments: disable
+  document-start: disable
+  line-length: disable
+  truthy: disable

--- a/conf/site.yml
+++ b/conf/site.yml
@@ -34,11 +34,11 @@ default:
 
   # Site name given at installation phase
   site: Wundersite
-  
+
   # If the site is a multisite system where drupal is bootstrapped from a different directory than
   # current/sites/default, you can define the folder here. Also note the symlink/copying of sites.php
   #multisite_site: myspecialsite
- 
+
   # In development environments we usually want to use symlinks, note the settings.php linking
   link:
     - files: sites/default/files


### PR DESCRIPTION
Mainly to make sure they're free of syntax errors, but performs some other checks too.

* .travis.yml - lint the files on the CI, so PRs are checked
* yamllint is a config file that disables some rules. You can add or remove relevant ones here. See also https://yamllint.readthedocs.io/en/latest/rules.html for fine-tuning.
* conf/site.yml - little edit to trim trailing spaces
* .editorconfig helps maintain some coding standards based on file names, like trimming trailing spaces and file encoding. Get a plugin for your editor here: http://editorconfig.org/#download
