### PR TITLE
d8: Fix the build

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,7 @@
 extends: default
 
 rules:
+  braces: disable
   comments: disable
   document-start: disable
   line-length: disable

--- a/conf/commands.yml
+++ b/conf/commands.yml
@@ -48,4 +48,3 @@ backup:
       skip-database: yes
       ignore:
         - sites/default/files
-


### PR DESCRIPTION
There are lots of "too many spaces inside braces  (braces)" errors for the d8 branch (but not develop).
https://travis-ci.org/wunderkraut/build.sh/jobs/183903630

Let's just ignore those errors. See also https://github.com/wunderkraut/build.sh/pull/59.

Also there's a fix that wasn't synced across to d8 from master.