### PR TITLE
develop: ignore errors for d8 branch

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,7 @@
 extends: default
 
 rules:
+  braces: disable
   comments: disable
   document-start: disable
   line-length: disable


### PR DESCRIPTION
There are lots of "too many spaces inside braces  (braces)" errors for the d8 branch (but not develop).
https://travis-ci.org/wunderkraut/build.sh/jobs/183903630

Let's just ignore those errors.

See also https://github.com/wunderkraut/build.sh/pull/58.