### PR TITLE
Ignore indentation errors to fix the build

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -4,5 +4,6 @@ extends: default
 rules:
   comments: disable
   document-start: disable
+  indentation: disable
   line-length: disable
   truthy: disable


### PR DESCRIPTION
Commit https://github.com/wunderkraut/build.sh/commit/4cbfe24ed0bbb97b23673aaef285bfd5b9c43275 broke the build by tightening up .travis.yml, but it's still valid as far as Travis CI is concerned, so let's skip those errors.