### PR TITLE
Test on Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 - 3.5
 - 3.4
 - 3.3
+- 2.6
 sudo: false
 install:
 - travis_retry pip install pyflakes
@@ -20,6 +21,7 @@ matrix:
   - python: 3.5
   - python: 3.4
   - python: 3.3
+  - python: 2.6
 notifications:
   email: false
   slack:


### PR DESCRIPTION
Commit https://github.com/wunderkraut/build.sh/commit/86a5e2c4c67e33f89b8216cd528177c4084d98a5 is for compatibility with Python < 2.7, so Python 2.6 should be tested on the CI.

I've put it last in the build order because CPython 2.6 itself has been unsupported for three years: https://en.wikipedia.org/wiki/CPython#Version_history