### PR TITLE
Allow Python 2.6 to fail the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ matrix:
   - python: 3.5
   - python: 3.4
   - python: 3.3
-  - python: 2.6
 notifications:
   email: false
   slack:


### PR DESCRIPTION
It's currently passing, let's keep it that way, as it's still needed by some old boxes.