### PR TITLE
Colons cause problems in Windows shared dirs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -468,6 +468,7 @@ class Maker:
 
         name = datetime.datetime.now()
         name = name.isoformat()
+        name = name.replace(":", "_")
 
         backup_file = self.old_build_dir + "/" + name + ".tgz"
 


### PR DESCRIPTION
For example:
```
** BUILD NOTICE: Backing up current build
** BUILD NOTICE: Database dump taken
** BUILD ERROR: [Errno 71] Protocol error: '/var/www/mysite/drupal/builds/2016-12-20T12:48:38.545177.tgz'
```