### PR TITLE
Run composer update instead of install on local environment

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -163,14 +163,20 @@ class Maker:
         self.link()
 
         params = []
+        method = 'update'
 
         # Do not install dev packages on non-development environments
+        # Use update method on local environment and install on all others
+        # since install method uses an existing composer.lock file whereas
+        # update method runs composer.json and updates composer.lock file.
         if self.site_env != 'default' and self.site_env != 'local':
             params.append('--no-dev')
+            method = 'install'
 
+        self.notice("Run composer " + method)
         self._composer([
             '-d=' + self.temp_build_dir,
-            'install'
+            method
         ] + params)
 
     def _drush_make(self):


### PR DESCRIPTION
Composer uses composer.lock file when running composer install. This is good when deploying production because lock file defines specific versions of your dependencies. However, you must update your composer.json (and the lock file) eventually and `composer update` is there for you. Let's use it with `./build.sh update local`

@see https://adamcod.es/2013/03/07/composer-install-vs-composer-update.html