### PR TITLE
Use realpath if absolute path is given relpath otherwise.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -583,7 +583,10 @@ class Maker:
         self._ensure_container(target)
         if not os.path.exists(target):
             if os.path.exists(source):
-                source = os.path.realpath(source)
+                if os.path.isabs(source):
+                    source = os.path.realpath(source)
+                else:
+                    source = os.path.relpath(source, os.path.dirname(target))
                 os.symlink(source, target)
             else:
                 raise BuildError("Can't link " + source + " to " + target + ". Make sure that the source exists.")


### PR DESCRIPTION
On local environments some editors get confused if we use absolute paths.
This adds a check to make relative links when relative path is given in the site.yml anad still creates links to absolute paths when one is given.
This might require updates in site.yml to make sure all local environment links are referred relatively and production paths absolutely.