### PR TITLE
Allow environments to specify if composer dev packages should be installed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -188,8 +188,15 @@ class Maker:
 
         params = []
 
-        # Do not install dev packages on non-development environments
-        if self.site_env != 'default' and self.site_env != 'local':
+        # Check if environment allows installing of dev packages
+        if "allow_composer_dev" not in self.settings:
+            allow_dev = False
+        else:
+            allow_dev = self.settings['allow_composer_dev']
+
+        # By default Do not install dev packages on non-development environments
+	# Allow override to allow dev packages
+        if self.site_env != 'default' and self.site_env != 'local' and allow_dev != True:
             params.append('--no-dev')
 
         self._composer([


### PR DESCRIPTION
Example usage in site.yml:

```
staging:
  allow_composer_dev: true
  local_commands:
    build:
      - make
```