### PR TITLE
Option "--no-interaction" is added to "composer install" command

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -198,6 +198,7 @@ class Maker:
 	# Allow override to allow dev packages
         if self.site_env != 'default' and self.site_env != 'local' and allow_dev != True:
             params.append('--no-dev')
+            params.append('--no-interaction')
 
         if self.temp_build_dir_name == ".":
             self._composer([


### PR DESCRIPTION
This change adds `--no-interaction` option to `composer install` command on
non-development environments to prevent command line prompts on deployments. Default action as to whether changes need to be discarded can be defined in `composer.json` file with `discard-changes` option set to `true`, `false` or `stash`.

See also:
- Docs on global options - https://getcomposer.org/doc/03-cli.md#global-options
- Docs on "discard-changes" option - https://getcomposer.org/doc/06-config.md#discard-changes