### PR TITLE
Raise build error if composer install fails.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -201,14 +201,17 @@ class Maker:
             params.append('--no-interaction')
 
         if self.temp_build_dir_name == ".":
-            self._composer([
+            command_status = self._composer([
                 'install'
             ] + params)
         else:
-            self._composer([
+            command_status = self._composer([
                 '-d=' + self.temp_build_dir,
                 'install'
             ] + params)
+
+        if not command_status:
+            raise BuildError("Composer install failed")
 
     def _drush_make(self):
         global build_sh_disable_cache


### PR DESCRIPTION
When combination of Deploybot Atomic deployments and composer build is used there can be situations where some production server specific error creeps up (or something gets trough QA) and causes `composer install` to fail. At the moment `build.sh` does not raise any error in those situations and Deploybot assumes that all is well and proceeds to put the new broken release build in place. 

This adds very basic check if composer make succeeded and if not - raises a generic build error which forces the build to exit with non-0 exit code that Deploybot can catch.