### PR TITLE
With '-d=' build script couldn't find _build directory and composer …

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -206,7 +206,7 @@ class Maker:
             ] + params)
         else:
             command_status = self._composer([
-                '-d=' + self.temp_build_dir,
+                '--working-dir=' + self.temp_build_dir,
                 'install'
             ] + params)
 


### PR DESCRIPTION
With '-d=' build script couldn't find _build directory and composer install didn't start.