### PR TITLE
Raise build error if drush command fails.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -358,7 +358,11 @@ class Maker:
     # Execute a drush command
     def drush_command(self, command):
             drush_command = command.split(' ')
-            return self._drush(drush_command, False)
+
+            command_status = self._drush(drush_command, False)
+
+            if not command_status:
+                raise BuildError("Drush command failed")
 
     def append(self, command):
         files = command.split(">")


### PR DESCRIPTION
We should raise build error ir drush command fails. That could happen for example during config import and noone would notice if you're running the script in Deploybot or similar tool.