### PR TITLE
Resolve Python 3 compatibility issues

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -426,7 +426,7 @@ class Maker:
         if "link" not in self.settings:
             return
         for tuple in self.settings['link']:
-            source, target = tuple.items()[0]
+            source, target = list(tuple.items())[0]
             target = self.temp_build_dir + "/" + target
             if source.endswith('*'):
                 path = source[:-1]
@@ -443,7 +443,7 @@ class Maker:
         if "link" not in self.settings:
             return
         for tuple in self.settings['link']:
-            source, target = tuple.items()[0]
+            source, target = list(tuple.items())[0]
             target = self.final_build_dir + "/" + target
             if source.endswith('*'):
                 path = source[:-1]


### PR DESCRIPTION
When used with Python 3.6+ the script throws a `TypeError: 'dict_items' object is not subscriptable` error. These minor changes seem to fix that.